### PR TITLE
fix: use endpoint-specific sort parameters for entities and files

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -95,7 +95,7 @@ paths:
               $ref: "#/components/schemas/EntityType"
         - $ref: "#/components/parameters/LimitParameter"
         - $ref: "#/components/parameters/OffsetParameter"
-        - $ref: "#/components/parameters/SortParameter"
+        - $ref: "#/components/parameters/EntitySortParameter"
         - $ref: "#/components/parameters/OrderParameter"
       responses:
         "200":
@@ -473,7 +473,7 @@ paths:
             type: string
         - $ref: "#/components/parameters/LimitParameter"
         - $ref: "#/components/parameters/OffsetParameter"
-        - $ref: "#/components/parameters/SortParameter"
+        - $ref: "#/components/parameters/FileSortParameter"
         - $ref: "#/components/parameters/OrderParameter"
       responses:
         "200":
@@ -669,16 +669,28 @@ components:
         format: int32
         minimum: 0
         default: 0
-    SortParameter:
+    EntitySortParameter:
       name: sort
       in: query
-      description: Field to sort by, such as `id` or `createdAt`.
+      description: Field to sort by, such as `name` or `createdAt`.
       example: id
       schema:
         type: string
         enum:
           - id
           - name
+          - createdAt
+          - updatedAt
+        default: id
+    FileSortParameter:
+      name: sort
+      in: query
+      description: Field to sort by, such as `filename` or `createdAt`.
+      example: id
+      schema:
+        type: string
+        enum:
+          - id
           - filename
           - createdAt
           - updatedAt


### PR DESCRIPTION
## Summary
- Replace shared sort parameter with endpoint-specific sort parameters for entities and files

## Test plan
- [ ] Verify the OpenAPI spec validates correctly
- [ ] Confirm each endpoint has appropriate sort options