### PR TITLE
feat: add extension framework, GET /capabilities, and segments extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and the specification adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.0] - 2026-07-06
+## [0.1.0] - 2026-07-13
 
 ### Added
 
@@ -18,21 +18,33 @@ and the specification adheres to
   prefixed identifier.
 - A required `GET /capabilities` endpoint through which every conformant
   implementation declares the spec version it targets (`apiVersion`), the
-  extensions it implements (`extensions`), and the search facets it supports
-  (`facets`). **Conformance-affecting**: existing implementations must add
+  extensions it implements (`extensions`), and its search capabilities
+  (`search`). **Conformance-affecting**: existing implementations must add
   this endpoint.
+- The `search` capability object declares the implementation's search
+  `filters` (each with a required `type` — `string`, `date`, `number`, or
+  `boolean` — and an optional `label`) and its search `facets`. Every facet
+  field must also be declared as a filter, so a facet value the user clicks
+  can always be applied as a filter.
+- Search request `filters` values may now be an inclusive `gte`/`lte` range
+  object as well as an array of exact values. Ranges are valid only for
+  filters declared with type `date` or `number`. Requests using an undeclared
+  filter field, or a range on a `string`/`boolean` filter, are rejected with
+  a 400 `ValidationError`.
 - The `segments` extension — the first registered extension. Adds an optional
   `searchExtra.segments` array to search hits: structured drill-down locations
-  (PDF pages via `PageSegment`, ELAN annotations via `AnnotationSegment`) for
-  full-text matches inside files, expressed as a discriminated union on
-  `type`.
+  (PDF pages via `PageSegment`, time-aligned annotations such as ELAN via
+  `TimeAlignedAnnotationSegment`) for full-text matches inside files,
+  expressed as a discriminated union on `type`.
 - This changelog.
 
 ### Changed
 
-- The Extensions guide is rewritten to document the extension model, the
-  curated registry, `/capabilities` feature detection, and client rules. The
-  legacy Oni-UI properties remain documented pending registration.
+- The Extensions guide moved to a dedicated top-level docs section with a
+  page per extension: the extension model and registry on the index page, a
+  detailed `segments` page (including non-normative Elasticsearch
+  implementation notes), and the legacy Oni-UI properties on their own page
+  pending registration.
 
 ## [0.0.1] - 2024-12-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,42 @@
+# Changelog
+
+All notable changes to the RO-Crate API specification are documented in this
+file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and the specification adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2026-07-06
+
+### Added
+
+- An extension framework: extensions are first-class citizens of the
+  specification, registered in the OpenAPI document with a stable identifier,
+  a schema, and semantics. Extension properties are tagged with an
+  `x-extension: <id>` annotation. Unregistered experiments use an `x-`
+  prefixed identifier.
+- A required `GET /capabilities` endpoint through which every conformant
+  implementation declares the spec version it targets (`apiVersion`), the
+  extensions it implements (`extensions`), and the search facets it supports
+  (`facets`). **Conformance-affecting**: existing implementations must add
+  this endpoint.
+- The `segments` extension — the first registered extension. Adds an optional
+  `searchExtra.segments` array to search hits: structured drill-down locations
+  (PDF pages via `PageSegment`, ELAN annotations via `AnnotationSegment`) for
+  full-text matches inside files, expressed as a discriminated union on
+  `type`.
+- This changelog.
+
+### Changed
+
+- The Extensions guide is rewritten to document the extension model, the
+  curated registry, `/capabilities` feature detection, and client rules. The
+  legacy Oni-UI properties remain documented pending registration.
+
+## [0.0.1] - 2024-12-20
+
+### Added
+
+- Initial specification: entities, files, and search endpoints with
+  authentication, rate limiting, and error handling conventions.

--- a/blog/2024-12-20-api-announcement.md
+++ b/blog/2024-12-20-api-announcement.md
@@ -6,3 +6,5 @@ tags: [paradisec, ldaca]
 ---
 
 TODO: Document the first release of our API
+
+{/* truncate */}

--- a/blog/2026-07-06-extensions-and-capabilities.md
+++ b/blog/2026-07-06-extensions-and-capabilities.md
@@ -10,7 +10,7 @@ citizens: a curated extension registry, a new required `GET /capabilities`
 endpoint for feature detection, and the first registered extension —
 `segments` — which lets search hits point inside files.
 
-<!-- truncate -->
+{/* truncate */}
 
 ## Why
 

--- a/blog/2026-07-06-extensions-and-capabilities.md
+++ b/blog/2026-07-06-extensions-and-capabilities.md
@@ -41,14 +41,26 @@ endpoint:
 ```json
 {
   "apiVersion": "0.1.0",
-  "extensions": { "segments": { "maxSegments": 5 } },
-  "facets": { "inLanguage": { "label": "Language" }, "mediaType": {} }
+  "extensions": { "segments": {} },
+  "search": {
+    "filters": {
+      "inLanguage": { "type": "string", "label": "Language" },
+      "createdAt": { "type": "date", "label": "Date created" }
+    },
+    "facets": { "inLanguage": { "label": "Language" }, "mediaType": {} }
+  }
 }
 ```
 
 Detection is a key lookup: an archive supports an extension exactly when its
-identifier appears in `extensions`. The `facets` map lets portals build facet
-UI dynamically instead of hard-coding per-archive facet lists.
+identifier appears in `extensions`. The `search` object lets portals build
+their search UI dynamically instead of hard-coding per-archive field lists:
+`filters` declares the fields a search request may filter on, each with a
+type (`string`, `date`, `number`, or `boolean`) that tells the portal which
+UI element to render — and `date` and `number` filters accept inclusive
+`gte`/`lte` range objects in search requests. `facets` declares the fields
+returned with facet counts, and every facet field is guaranteed to also be
+filterable, so clicking a facet value always works as a filter.
 
 This is the one conformance-affecting change in 0.1.0: existing
 implementations need to add the endpoint.
@@ -69,8 +81,9 @@ the union grows.
 
 ## Where to go next
 
-- The [Extensions guide](/docs/getting-started/extensions) explains the
-  extension model, the registry, and the client rules.
+- The [Extensions guide](/docs/extensions) explains the extension model, the
+  registry, and the client rules; the [segments page](/docs/extensions/segments)
+  covers the first extension in depth, including implementation notes.
 - The [API reference](/docs/api) documents `/capabilities` and the segment
   schemas.
 - The specification now has a

--- a/blog/2026-07-06-extensions-and-capabilities.md
+++ b/blog/2026-07-06-extensions-and-capabilities.md
@@ -1,0 +1,78 @@
+---
+slug: extensions-and-capabilities
+title: "Introducing API Extensions, /capabilities, and the segments extension"
+authors: [johnf]
+tags: [paradisec, ldaca]
+---
+
+Version 0.1.0 of the RO-Crate API specification makes extensions first-class
+citizens: a curated extension registry, a new required `GET /capabilities`
+endpoint for feature detection, and the first registered extension —
+`segments` — which lets search hits point inside files.
+
+<!-- truncate -->
+
+## Why
+
+Archives implementing this API extend it with implementation-specific response
+properties, but until now the specification had no rigorous way to define,
+discover, or evolve those extensions. Portal implementers had no way to know
+what a given archive supports — which extensions, or even which search facets —
+without per-archive configuration or probing.
+
+## The extension registry
+
+Extensions are now specified in the OpenAPI document itself. Every extension
+has a stable identifier, a schema, and semantics. Extension properties appear
+inline in core schemas as optional fields, each tagged with an
+`x-extension: <id>` annotation, so the boundary between core and extension is
+machine-readable. Anyone can propose a new extension via a pull request to the
+specification repository; unregistered private experiments use an `x-`
+prefixed identifier.
+
+Implementations choose which extensions to implement — you remain conformant
+while implementing only the ones relevant to your corpus.
+
+## GET /capabilities
+
+Every conformant implementation now declares what it supports through a single
+endpoint:
+
+```json
+{
+  "apiVersion": "0.1.0",
+  "extensions": { "segments": { "maxSegments": 5 } },
+  "facets": { "inLanguage": { "label": "Language" }, "mediaType": {} }
+}
+```
+
+Detection is a key lookup: an archive supports an extension exactly when its
+identifier appears in `extensions`. The `facets` map lets portals build facet
+UI dynamically instead of hard-coding per-archive facet lists.
+
+This is the one conformance-affecting change in 0.1.0: existing
+implementations need to add the endpoint.
+
+## The segments extension
+
+`segments` is the first registered extension. It adds an optional
+`searchExtra.segments` array to search hits, carrying structured drill-down
+locations for full-text matches inside files — a 1-based page number for PDF
+matches, or an ELAN tier and time range for transcription matches — each with
+highlight fragments. Portals can deep-link users straight to the matching page
+of a PDF or the matching utterance in a media player.
+
+Segments are a discriminated union on `type`, so generated client types give
+you precise per-variant fields. New segment types arrive by spec revision, and
+clients skip types they don't recognise, so deployed clients keep working as
+the union grows.
+
+## Where to go next
+
+- The [Extensions guide](/docs/getting-started/extensions) explains the
+  extension model, the registry, and the client rules.
+- The [API reference](/docs/api) documents `/capabilities` and the segment
+  schemas.
+- The specification now has a
+  [changelog](https://github.com/Language-Research-Technology/ro-crate-api/blob/main/CHANGELOG.md)
+  recording changes from 0.1.0 onwards.

--- a/docs/extensions/index.md
+++ b/docs/extensions/index.md
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 6
 title: Extensions
 mdx.format: md
 ---
@@ -8,7 +7,9 @@ mdx.format: md
 
 This guide explains how the RO-Crate API specification is extended: the
 extension model, the curated registry, feature detection through
-[`/capabilities`](./capabilities), and the rules clients must follow.
+[`/capabilities`](/docs/getting-started/capabilities), and the rules clients
+must follow. Each registered extension has its own page describing it in
+detail.
 
 ## The Extension Model
 
@@ -22,8 +23,8 @@ Every extension has:
 - **A stable identifier** (e.g. `segments`) used to declare and detect it
 - **A schema** defining the response properties it adds
 - **Semantics** describing how those properties behave
-- **A configuration schema** defining what the implementation declares about
-  the extension in `/capabilities`
+- **A capability schema** defining the extra details an implementation
+  communicates about the extension in `/capabilities`
 
 Extensions are optional. An implementation remains conformant while
 implementing only the extensions relevant to its corpus — or none at all.
@@ -35,7 +36,8 @@ extension is defined in the OpenAPI document: its properties appear inline in
 core schemas as optional fields, each tagged with an `x-extension: <id>`
 annotation so the boundary between core and extension is machine-readable.
 Normative detail lives in the schema descriptions and is rendered on the
-generated API reference pages.
+generated API reference pages; each extension also has a guide page here with
+examples and implementation notes.
 
 To propose a new extension (or a new variant within an existing one, such as a
 new segment type), open a pull request against
@@ -45,9 +47,15 @@ consumers a single authoritative definition.
 
 ### Registered Extensions
 
-| Identifier | Adds | Configuration |
+| Identifier | Adds | Capability details |
 | --- | --- | --- |
-| `segments` | `searchExtra.segments` — structured drill-down locations (PDF pages, ELAN annotations) for full-text search matches inside files | `maxSegments`: the per-hit segment cap |
+| [`segments`](./segments) | `searchExtra.segments` — structured drill-down locations (PDF pages, time-aligned annotations) for full-text search matches inside files | none |
+
+### Legacy Extensions
+
+A handful of properties used by the [oni-ui](https://github.com/Language-Research-Technology/oni-ui)
+implementation predate the registry. They are documented on the
+[Legacy Extensions](./legacy) page until they are formally registered.
 
 ### Experimental Extensions
 
@@ -60,9 +68,10 @@ across implementations.
 ## Feature Detection
 
 Implementations declare their implemented extensions in the `extensions`
-member of [`/capabilities`](./capabilities), a map of extension identifier to
-configuration object. Detection is a simple key lookup: an archive supports
-segments exactly when `"segments" in capabilities.extensions`.
+member of [`/capabilities`](/docs/getting-started/capabilities), a map of
+extension identifier to a details object. Detection is a simple key
+lookup: an archive supports segments exactly when
+`"segments" in capabilities.extensions`.
 
 ## Client Rules
 
@@ -76,40 +85,3 @@ Clients that work across implementations MUST follow these rules:
    (such as segment `type`), skip values you do not recognise rather than
    fail — new variants are added by spec revision and deployed clients must
    keep working
-
-## Legacy Extensions (Pending Registration)
-
-The properties below predate the extension registry. The
-[oni-ui](https://github.com/Language-Research-Technology/oni-ui) implementation
-expects them at the root level of entity responses. They remain documented here
-until they are formally registered as extensions.
-
-### Statistical Counts
-
-- **`counts`** (object): Statistical information about the entity's subtree:
-  - **`collections`** (integer): The total number of collections in the subtree
-  - **`objects`** (integer): The total number of objects in the subtree
-  - **`subCollections`** (integer): The number of nested sub-collections within
-  this entity
-  - **`files`** (integer): The number of individual files attached to or within
-  this entity's structure
-
-### Content Classification
-
-- **`language`** (array of strings): All languages contained in the sub-tree of
-entities. Useful for archives that store diverse linguistic data.
-  - Example: `["English", "Italian", "Mandarin"]`
-
-- **`communicationMode`** (array of strings): The modes of communication found
-in this sub-tree's data, such as speech, song, or sign.
-  - Example: `["SpokenLanguage", "Song", "SignLanguage"]`
-
-- **`mediaType`** (array of strings): Media types (MIME types) of files within
-the sub-tree.
-  - Example: `["audio/wav", "text/plain", "video/mp4"]`
-
-### Access Control
-
-- **`accessControl`** (string): The level of access control required to view or
-download this entity.
-  - Example: `"Public"`, `"Restricted"`, `"Private"`

--- a/docs/extensions/legacy.md
+++ b/docs/extensions/legacy.md
@@ -1,0 +1,42 @@
+---
+sidebar_position: 99
+title: Legacy Extensions
+mdx.format: md
+---
+
+# Legacy Extensions (Pending Registration)
+
+The properties below predate the extension registry. The
+[oni-ui](https://github.com/Language-Research-Technology/oni-ui) implementation
+expects them at the root level of entity responses. They remain documented here
+until they are formally registered as extensions.
+
+## Statistical Counts
+
+- **`counts`** (object): Statistical information about the entity's subtree:
+  - **`collections`** (integer): The total number of collections in the subtree
+  - **`objects`** (integer): The total number of objects in the subtree
+  - **`subCollections`** (integer): The number of nested sub-collections within
+  this entity
+  - **`files`** (integer): The number of individual files attached to or within
+  this entity's structure
+
+## Content Classification
+
+- **`language`** (array of strings): All languages contained in the sub-tree of
+entities. Useful for archives that store diverse linguistic data.
+  - Example: `["English", "Italian", "Mandarin"]`
+
+- **`communicationMode`** (array of strings): The modes of communication found
+in this sub-tree's data, such as speech, song, or sign.
+  - Example: `["SpokenLanguage", "Song", "SignLanguage"]`
+
+- **`mediaType`** (array of strings): Media types (MIME types) of files within
+the sub-tree.
+  - Example: `["audio/wav", "text/plain", "video/mp4"]`
+
+## Access Control
+
+- **`accessControl`** (string): The level of access control required to view or
+download this entity.
+  - Example: `"Public"`, `"Restricted"`, `"Private"`

--- a/docs/extensions/segments.md
+++ b/docs/extensions/segments.md
@@ -1,0 +1,213 @@
+---
+sidebar_position: 1
+title: "Extension: segments"
+mdx.format: md
+---
+
+# The `segments` Extension
+
+Full-text search tells a user *which file* matched their query. For a
+three-hundred-page PDF of field notes or an hour of transcribed audio, that is
+not enough — the user still has to hunt for the match inside the file. The
+`segments` extension closes that gap: each search hit can carry a list of
+**segments**, structured locations inside the file where the match occurred,
+so clients can deep-link the user straight to the matching page of a PDF or
+the matching utterance in a media player.
+
+Segments appear as an optional `searchExtra.segments` array on
+[search](/docs/api/search-entities) hits. The array is ranked by relevance and
+capped at an implementation-defined limit.
+
+## Declaring the Capability
+
+An implementation that provides segments declares the extension in
+[`/capabilities`](/docs/getting-started/capabilities):
+
+```json
+{
+  "apiVersion": "0.1.0",
+  "extensions": {
+    "segments": {}
+  }
+}
+```
+
+The extension currently has no extra details to communicate, so the value is
+an empty object — presence of the `segments` key is the declaration.
+
+Clients detect support with a key lookup
+(`"segments" in capabilities.extensions`) and MUST degrade gracefully when
+the key is absent — hide the deep-link affordance, don't fail.
+
+## The Response Shape
+
+Each segment is one of the registered segment types, discriminated by `type`.
+Two types are registered:
+
+### `page`
+
+A match located on a page of a paginated document, such as a PDF.
+
+```json
+{
+  "type": "page",
+  "page": 3,
+  "highlight": ["a wordlist of <em>West Alor</em> terms for kinship"]
+}
+```
+
+- **`page`** (integer, ≥ 1): the 1-based page number the match occurred on
+- **`highlight`** (array of strings): matched text fragments from this page,
+  using the same marking convention as `searchExtra.highlight`
+
+### `time-aligned-annotation`
+
+A match located in a time-aligned annotation, such as an ELAN annotation
+tier.
+
+```json
+{
+  "type": "time-aligned-annotation",
+  "tier": "A_phrase-segnum-en",
+  "startMs": 83000,
+  "endMs": 87500,
+  "highlight": ["the speaker lists <em>West Alor</em> place names"]
+}
+```
+
+- **`tier`** (string): the identifier of the annotation tier the match
+  occurred in (for ELAN, the `TIER_ID`)
+- **`startMs`** / **`endMs`** (integers, ≥ 0): the annotation's time range,
+  in milliseconds from the beginning of the media
+- **`highlight`** (array of strings): matched text fragments from this
+  annotation
+
+### A Full Search Hit
+
+A search for `West Alor` might return this hit for a PDF of field notes with
+an accompanying transcription:
+
+```json
+{
+  "id": "https://catalog.paradisec.org.au/repository/NT1/001/NT1-001-001A.pdf",
+  "name": "NT1-001-001A.pdf",
+  "entityType": "http://schema.org/MediaObject",
+  "searchExtra": {
+    "score": 0.87,
+    "highlight": { "content": ["notes on <em>West Alor</em> vocabulary"] },
+    "segments": [
+      {
+        "type": "page",
+        "page": 3,
+        "highlight": ["a wordlist of <em>West Alor</em> terms for kinship"]
+      },
+      {
+        "type": "time-aligned-annotation",
+        "tier": "A_phrase-segnum-en",
+        "startMs": 83000,
+        "endMs": 87500,
+        "highlight": ["the speaker lists <em>West Alor</em> place names"]
+      }
+    ]
+  }
+}
+```
+
+A client can render "matched on page 3" as a link opening the PDF viewer at
+that page, and "matched at 1:23" as a link starting media playback at 83
+seconds.
+
+## Client Rules
+
+- **Segments are optional per hit.** Absent or empty means the hit had no
+  structured content to point into — the hit itself is still valid.
+- **Skip unknown types.** New segment types are added by revision of this
+  specification. A client that encounters a `type` it does not recognise MUST
+  skip that segment rather than fail, so deployed clients keep working as the
+  union grows.
+- **Expect a cap.** Segments are ranked by relevance and capped at an
+  implementation-defined limit per hit, so a full-looking list is not
+  necessarily exhaustive.
+
+New segment types are proposed by pull request against the
+[specification repository](https://github.com/Language-Research-Technology/ro-crate-api) —
+see [the registry](./#the-curated-registry).
+
+## Implementation Notes (Non-Normative)
+
+This section is guidance, not specification. It sketches one proven way to
+implement segments with Elasticsearch; any implementation that produces
+conformant responses is equally valid.
+
+### Index-time extraction
+
+Segments must exist in the index before they can be searched. At ingest
+time, extract per-segment records from each file:
+
+- **PDFs and other paginated documents**: extract text page by page (e.g.
+  with `pdftotext` or Apache Tika), producing one record per page with its
+  1-based page number.
+- **ELAN files (`.eaf`)**: walk each annotation tier, producing one record
+  per annotation with the tier's `TIER_ID` and the annotation's time slot
+  values in milliseconds.
+
+### Mapping
+
+Store the extracted records as [`nested`](https://www.elastic.co/guide/en/elasticsearch/reference/current/nested.html)
+documents on the file's entity document, so each segment's fields stay
+associated with each other:
+
+```json
+{
+  "mappings": {
+    "properties": {
+      "segments": {
+        "type": "nested",
+        "properties": {
+          "type": { "type": "keyword" },
+          "text": { "type": "text" },
+          "page": { "type": "integer" },
+          "tier": { "type": "keyword" },
+          "startMs": { "type": "long" },
+          "endMs": { "type": "long" }
+        }
+      }
+    }
+  }
+}
+```
+
+### Querying
+
+Combine the entity-level query with a `nested` query over the segments, and
+use [`inner_hits`](https://www.elastic.co/guide/en/elasticsearch/reference/current/inner-hits.html)
+to retrieve the matching segments — `inner_hits` returns the top-scoring
+nested documents per hit, which is exactly the ranked, capped list the
+extension requires:
+
+```json
+{
+  "query": {
+    "bool": {
+      "should": [
+        { "match": { "content": "West Alor" } },
+        {
+          "nested": {
+            "path": "segments",
+            "query": { "match": { "segments.text": "West Alor" } },
+            "inner_hits": {
+              "size": 5,
+              "highlight": { "fields": { "segments.text": {} } }
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+Set `inner_hits.size` to your chosen per-hit segment cap. Each inner hit maps
+directly onto a response segment: the `type` field selects `page` or
+`time-aligned-annotation`, the per-type fields come from the nested source,
+and the `highlight` fragments become the segment's `highlight` array.

--- a/docs/getting-started/capabilities.md
+++ b/docs/getting-started/capabilities.md
@@ -15,8 +15,18 @@ it instead of relying on per-archive configuration or probing responses.
 ```json
 {
   "apiVersion": "0.1.0",
-  "extensions": { "segments": { "maxSegments": 5 } },
-  "facets": { "inLanguage": { "label": "Language" }, "mediaType": {} }
+  "extensions": { "segments": {} },
+  "search": {
+    "filters": {
+      "inLanguage": { "type": "string", "label": "Language" },
+      "mediaType": { "type": "string" },
+      "createdAt": { "type": "date", "label": "Date created" }
+    },
+    "facets": {
+      "inLanguage": { "label": "Language" },
+      "mediaType": {}
+    }
+  }
 }
 ```
 
@@ -33,22 +43,48 @@ records what changed in each version.
 ### `extensions`
 
 The registered extensions the implementation provides, as a map of extension
-identifier to that extension's configuration object. Presence of a key means
-the extension is implemented; the value is an empty object when the extension
-has nothing to configure.
+identifier to a details object describing how that extension is provided.
+Presence of a key means the extension is implemented; the value is an empty
+object when the extension has no extra details to communicate.
 
 Detection is a simple key lookup: an archive supports segments exactly when
 `"segments" in capabilities.extensions`. See the
-[Extensions guide](./extensions) for the extension model and the rules clients
-must follow.
+[Extensions guide](/docs/extensions) for the extension model and the rules
+clients must follow.
 
-### `facets`
+### `search.filters`
+
+The fields that may be used in the search request's `filters` object, as a map
+of field name to its declaration. Each filter declares a required `type` —
+`string`, `date`, `number`, or `boolean` — and an optional display `label`.
+
+The type tells you which UI element suits the field (a date picker for `date`,
+a toggle for `boolean`) and which request syntax it accepts: every filter
+accepts an array of exact values, and `date` and `number` filters additionally
+accept an inclusive range object:
+
+```json
+{
+  "filters": {
+    "inLanguage": ["English"],
+    "createdAt": { "gte": "2020-01-01", "lte": "2021-01-01" }
+  }
+}
+```
+
+Requests using a filter field the implementation did not declare — or sending
+a range to a `string` or `boolean` filter — are rejected with a 400
+`ValidationError`, so build filter UI from this map rather than hard-coding
+field lists. Hide filters whose `type` you do not recognise; new types are
+added by spec revision.
+
+### `search.facets`
 
 The facet fields the implementation supports in search, as a map of field name
-to configuration with an optional display `label`. Use it to build facet UI
-dynamically instead of hard-coding per-archive facet lists: each field listed
-here may be used in search `filters` and appears in the search response's
-facet counts.
+to its declaration, with an optional display `label`. Each field listed here
+appears in the search response's facet counts, and is guaranteed to also be
+declared in `search.filters` — so a facet value the user clicks can always be
+applied as a filter on the next request.
 
 ## Using Capabilities
 

--- a/docs/getting-started/capabilities.md
+++ b/docs/getting-started/capabilities.md
@@ -1,0 +1,58 @@
+---
+sidebar_position: 5
+title: Capabilities
+mdx.format: md
+---
+
+# Capabilities
+
+Every conformant implementation provides `GET /capabilities`: a single endpoint
+that declares what the implementation supports. Clients feature-detect against
+it instead of relying on per-archive configuration or probing responses.
+
+## The Response
+
+```json
+{
+  "apiVersion": "0.1.0",
+  "extensions": { "segments": { "maxSegments": 5 } },
+  "facets": { "inLanguage": { "label": "Language" }, "mediaType": {} }
+}
+```
+
+The full schema is documented in the
+[API reference](/docs/api/get-capabilities).
+
+### `apiVersion`
+
+The version of this specification the implementation targets. Use it to reason
+about core-level differences between archives as the specification evolves —
+the [changelog](https://github.com/Language-Research-Technology/ro-crate-api/blob/main/CHANGELOG.md)
+records what changed in each version.
+
+### `extensions`
+
+The registered extensions the implementation provides, as a map of extension
+identifier to that extension's configuration object. Presence of a key means
+the extension is implemented; the value is an empty object when the extension
+has nothing to configure.
+
+Detection is a simple key lookup: an archive supports segments exactly when
+`"segments" in capabilities.extensions`. See the
+[Extensions guide](./extensions) for the extension model and the rules clients
+must follow.
+
+### `facets`
+
+The facet fields the implementation supports in search, as a map of field name
+to configuration with an optional display `label`. Use it to build facet UI
+dynamically instead of hard-coding per-archive facet lists: each field listed
+here may be used in search `filters` and appears in the search response's
+facet counts.
+
+## Using Capabilities
+
+Fetch `/capabilities` once when your client starts a session with an archive
+and cache the result — it describes the deployment, not individual requests.
+Degrade gracefully when a capability is absent: hide the feature rather than
+failing.

--- a/docs/getting-started/error-handling.md
+++ b/docs/getting-started/error-handling.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 7
 title: Error Handling
 ---
 

--- a/docs/getting-started/extensions.md
+++ b/docs/getting-started/extensions.md
@@ -6,58 +6,98 @@ mdx.format: md
 
 # API Extensions
 
-This guide explains how implementations can extend the RO-Crate API
-specification with additional properties.
+This guide explains how the RO-Crate API specification is extended: the
+extension model, the curated registry, feature detection through
+`/capabilities`, and the rules clients must follow.
 
-## Core vs Extension Properties
+## The Extension Model
 
-The RO-Crate API specification defines mandatory fields that all
-implementations must provide. However, implementations are free to add optional
-extension properties directly at the root level of entity responses to meet
-their specific requirements.
+The core specification defines the endpoints and fields every implementation
+must provide. Beyond that core, functionality is added through **extensions**:
+optional, well-defined units of behaviour that implementations choose to
+provide.
 
-**Important**: Extension properties are implementation-specific and not
-required by the core API. Clients should be prepared to handle additional
-properties beyond those defined in the specification.
+Every extension has:
 
-## How Extensions Work
+- **A stable identifier** (e.g. `segments`) used to declare and detect it
+- **A schema** defining the response properties it adds
+- **Semantics** describing how those properties behave
+- **A configuration schema** defining what the implementation declares about
+  the extension in `/capabilities`
 
-Extension properties are added at the root level of entity objects, alongside
-the mandatory fields defined in the API specification. For example:
+Extensions are optional. An implementation remains conformant while
+implementing only the extensions relevant to its corpus — or none at all.
+
+## The Curated Registry
+
+Extensions are registered in the specification itself. Each registered
+extension is defined in the OpenAPI document: its properties appear inline in
+core schemas as optional fields, each tagged with an `x-extension: <id>`
+annotation so the boundary between core and extension is machine-readable.
+Normative detail lives in the schema descriptions and is rendered on the
+generated API reference pages.
+
+To propose a new extension (or a new variant within an existing one, such as a
+new segment type), open a pull request against
+[this specification repository](https://github.com/Language-Research-Technology/ro-crate-api).
+Registration keeps identifiers stable and collision-free, and gives all
+consumers a single authoritative definition.
+
+### Registered Extensions
+
+| Identifier | Adds | Configuration |
+| --- | --- | --- |
+| `segments` | `searchExtra.segments` — structured drill-down locations (PDF pages, ELAN annotations) for full-text search matches inside files | `maxSegments`: the per-hit segment cap |
+
+### Experimental Extensions
+
+Unregistered, private experiments MUST use an `x-` prefixed identifier (e.g.
+`x-my-experiment`). The `x-` prefix is a sanctioned lane for experimentation
+that cannot collide with registered identifiers. Experimental extensions are
+outside the scope of this specification; register them before relying on them
+across implementations.
+
+## Feature Detection with `/capabilities`
+
+Every conformant implementation provides `GET /capabilities`, which declares:
+
+- **`apiVersion`** — the specification version the implementation targets
+- **`extensions`** — a map of extension identifier to that extension's
+  configuration object. Presence of a key means the extension is implemented;
+  the value is an empty object when the extension has nothing to configure
+- **`facets`** — a map of the facet field names the implementation supports in
+  search, each with an optional display `label`
 
 ```json
 {
-  "id": "https://catalog.paradisec.org.au/repository/LRB/001",
-  "name": "Recordings of West Alor languages",
-  "description": "A compilation of recordings featuring various West Alor languages",
-  "entityType": "http://pcdm.org/models#Collection",
-  "memberOf": "https://catalog.paradisec.org.au/repository/LRB",
-  "rootCollection": "https://catalog.paradisec.org.au/repository/LRB",
-  "metadataLicenseId": "https://license.example.com/metadata",
-  "contentLicenseId": "https://license.example.com/content",
-  "access": {
-    "metadata": true,
-    "content": false
-  },
-
-  // Extension properties below
-  "counts": {
-    "collections": 5,
-    "objects": 42,
-    "subCollections": 3,
-    "files": 150
-  },
-  "language": ["English", "Italian"],
-  "communicationMode": ["SpokenLanguage", "Song"],
-  "mediaType": ["audio/wav", "text/plain"],
-  "accessControl": "Public"
+  "apiVersion": "0.1.0",
+  "extensions": { "segments": { "maxSegments": 5 } },
+  "facets": { "inLanguage": { "label": "Language" }, "mediaType": {} }
 }
 ```
 
-## Example: Oni-UI Extensions
+Detection is a simple key lookup: an archive supports segments exactly when
+`"segments" in capabilities.extensions`.
 
-The [oni-ui](https://github.com/Language-Research-Technology/oni-ui) implementation
-requires the following additional properties to be present in API responses:
+## Client Rules
+
+Clients that work across implementations MUST follow these rules:
+
+1. **Feature-detect before use**: check `/capabilities` rather than probing
+   responses or hard-coding per-archive behaviour
+2. **Tolerate absent extensions**: extension properties are optional; degrade
+   gracefully when an extension (or an individual property) is not present
+3. **Skip unknown variants**: where an extension defines a discriminated union
+   (such as segment `type`), skip values you do not recognise rather than
+   fail — new variants are added by spec revision and deployed clients must
+   keep working
+
+## Legacy Extensions (Pending Registration)
+
+The properties below predate the extension registry. The
+[oni-ui](https://github.com/Language-Research-Technology/oni-ui) implementation
+expects them at the root level of entity responses. They remain documented here
+until they are formally registered as extensions.
 
 ### Statistical Counts
 
@@ -88,28 +128,3 @@ the sub-tree.
 - **`accessControl`** (string): The level of access control required to view or
 download this entity.
   - Example: `"Public"`, `"Restricted"`, `"Private"`
-
-## Implementation Guidelines
-
-When adding extension properties to your API implementation:
-
-1. **Document your extensions**: Clearly document any additional properties
-   your implementation provides
-2. **Use descriptive names**: Choose property names that clearly indicate their
-   purpose
-3. **Consider namespacing**: For complex implementations, consider using
-   prefixed property names to avoid conflicts
-4. **Maintain consistency**: Use consistent data types and naming conventions
-   across your extensions
-5. **Version appropriately**: Consider how extension changes might affect
-   client compatibility
-
-## Other Implementations
-
-Different RO-Crate API implementations may define their own extension
-properties based on their specific use cases and requirements. Always consult
-the documentation for the specific implementation you're working with to
-understand what additional properties might be available.
-
-When building clients that work across multiple implementations, design them to
-gracefully handle unknown extension properties.

--- a/docs/getting-started/extensions.md
+++ b/docs/getting-started/extensions.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 6
 title: Extensions
 mdx.format: md
 ---
@@ -8,7 +8,7 @@ mdx.format: md
 
 This guide explains how the RO-Crate API specification is extended: the
 extension model, the curated registry, feature detection through
-`/capabilities`, and the rules clients must follow.
+[`/capabilities`](./capabilities), and the rules clients must follow.
 
 ## The Extension Model
 
@@ -57,27 +57,12 @@ that cannot collide with registered identifiers. Experimental extensions are
 outside the scope of this specification; register them before relying on them
 across implementations.
 
-## Feature Detection with `/capabilities`
+## Feature Detection
 
-Every conformant implementation provides `GET /capabilities`, which declares:
-
-- **`apiVersion`** — the specification version the implementation targets
-- **`extensions`** — a map of extension identifier to that extension's
-  configuration object. Presence of a key means the extension is implemented;
-  the value is an empty object when the extension has nothing to configure
-- **`facets`** — a map of the facet field names the implementation supports in
-  search, each with an optional display `label`
-
-```json
-{
-  "apiVersion": "0.1.0",
-  "extensions": { "segments": { "maxSegments": 5 } },
-  "facets": { "inLanguage": { "label": "Language" }, "mediaType": {} }
-}
-```
-
-Detection is a simple key lookup: an archive supports segments exactly when
-`"segments" in capabilities.extensions`.
+Implementations declare their implemented extensions in the `extensions`
+member of [`/capabilities`](./capabilities), a map of extension identifier to
+configuration object. Detection is a simple key lookup: an archive supports
+segments exactly when `"segments" in capabilities.extensions`.
 
 ## Client Rules
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -20,6 +20,10 @@ info:
 
     API implementations MAY implement rate limiting to ensure fair usage and system stability. When rate limiting is active, responses will include rate limit headers (`X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset`) and will return a 429 status code when limits are exceeded.
 
+    ## Extensions
+
+    The core specification can be extended through a curated registry of extensions defined in this document. Every extension has a stable identifier, a schema, and semantics. Implementations choose which extensions to implement and declare them through the `GET /capabilities` endpoint. Extension properties appear in core schemas as optional fields tagged with an `x-extension` annotation. See the [Extensions guide](https://language-research-technology.github.io/ro-crate-api/docs/getting-started/extensions) for the full extension model.
+
   contact:
     name: Issues
     url: https://github.com/Language-Research-Technology/ro-crate-api/issues
@@ -29,7 +33,7 @@ info:
   license:
     name: MIT
     identifier: MIT
-  version: 0.0.1
+  version: 0.1.0
 servers:
   - url: https://data.ldaca.edu.au/api
     description: LDaCA
@@ -39,6 +43,9 @@ externalDocs:
   description: Find out more about RO-Crate
   url: https://Language-Research-Technology.github.io/ro-crate-api
 tags:
+  - name: capabilities
+    description: Endpoint for discovering what an implementation supports — the spec version it targets, the extensions it implements, and the search facets it provides.
+    x-displayName: Capabilities
   - name: entities
     description: Endpoints related to the creation, retrieval, and management of RO-Crate entities.
     x-displayName: Entities
@@ -56,6 +63,7 @@ tags:
 x-tagGroups:
   - name: General
     tags:
+      - capabilities
       - entities
       - files
       - search
@@ -69,6 +77,36 @@ security:
   - OpenID:
       - read
 paths:
+  /capabilities:
+    get:
+      tags:
+        - capabilities
+      summary: Get implementation capabilities
+      description: |
+        ### Capabilities
+        Declare what this implementation supports — the spec version it targets, the extensions it implements, and the search facets it provides. Every conformant implementation MUST provide this endpoint so that clients can feature-detect rather than relying on per-archive configuration or probing.
+
+        See the [Extensions guide](https://language-research-technology.github.io/ro-crate-api/docs/getting-started/extensions) for how extensions are registered and how clients should use this endpoint.
+      operationId: getCapabilities
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Capabilities"
+              examples:
+                CapabilitiesResponse:
+                  $ref: "#/components/examples/CapabilitiesResponse"
+        "401":
+          $ref: "#/components/responses/UnauthorizedResponse"
+        "403":
+          $ref: "#/components/responses/ForbiddenResponse"
+        "429":
+          $ref: "#/components/responses/RateLimitResponse"
+        "500":
+          $ref: "#/components/responses/InternalServerErrorResponse"
+
   /entities:
     get:
       tags:
@@ -1019,6 +1057,135 @@ components:
         - asc
         - desc
       description: Used to specify the order in sorting results.
+    Capabilities:
+      type: object
+      description: Declares what an implementation supports — the spec version it targets, the registered extensions it implements, and the search facets it provides.
+      required:
+        - apiVersion
+        - extensions
+        - facets
+      properties:
+        apiVersion:
+          type: string
+          description: The version of this specification that the implementation targets.
+          example: "0.1.0"
+        extensions:
+          type: object
+          description: |
+            The registered extensions this implementation provides, as a map of extension identifier to the extension's configuration object. Presence of a key means the extension is implemented; the value is an empty object when the extension has nothing to configure.
+
+            Unregistered experimental extensions use an `x-` prefixed identifier and are outside the scope of this specification.
+          properties:
+            segments:
+              $ref: "#/components/schemas/SegmentsCapability"
+              x-extension: segments
+          additionalProperties:
+            type: object
+          example:
+            segments:
+              maxSegments: 5
+        facets:
+          type: object
+          description: The facet fields the implementation supports in search responses, as a map of facet field name to configuration.
+          additionalProperties:
+            $ref: "#/components/schemas/FacetCapability"
+          example:
+            inLanguage:
+              label: Language
+            mediaType: {}
+    SegmentsCapability:
+      type: object
+      description: Configuration for the `segments` extension.
+      x-extension: segments
+      required:
+        - maxSegments
+      properties:
+        maxSegments:
+          type: integer
+          minimum: 1
+          description: The implementation-defined maximum number of segments returned per search hit.
+          example: 5
+    FacetCapability:
+      type: object
+      description: Configuration for a search facet field.
+      properties:
+        label:
+          type: string
+          description: An optional human-readable display label for the facet field.
+          example: Language
+    Segment:
+      description: |
+        A location inside a file where a full-text search match occurred, allowing clients to deep-link the user to the match. Part of the `segments` extension.
+
+        Each segment is one of the registered segment types, discriminated by `type`. New segment types are added by revision of this specification; clients MUST skip segments with a `type` value they do not recognise rather than fail.
+      x-extension: segments
+      oneOf:
+        - $ref: "#/components/schemas/PageSegment"
+        - $ref: "#/components/schemas/AnnotationSegment"
+      discriminator:
+        propertyName: type
+        mapping:
+          page: "#/components/schemas/PageSegment"
+          annotation: "#/components/schemas/AnnotationSegment"
+    PageSegment:
+      type: object
+      description: A search match located on a page of a paginated document, such as a PDF.
+      x-extension: segments
+      required:
+        - type
+        - page
+        - highlight
+      properties:
+        type:
+          type: string
+          enum:
+            - page
+          description: The segment type discriminator.
+        page:
+          type: integer
+          minimum: 1
+          description: The 1-based page number the match occurred on.
+          example: 3
+        highlight:
+          type: array
+          items:
+            type: string
+          description: Matched text fragments from this page, using the same marking convention as `searchExtra.highlight`.
+    AnnotationSegment:
+      type: object
+      description: A search match located in a time-aligned annotation, such as an ELAN annotation tier.
+      x-extension: segments
+      required:
+        - type
+        - tier
+        - startMs
+        - endMs
+        - highlight
+      properties:
+        type:
+          type: string
+          enum:
+            - annotation
+          description: The segment type discriminator.
+        tier:
+          type: string
+          description: The identifier of the annotation tier the match occurred in (for ELAN, the TIER_ID).
+          example: A_phrase-segnum-en
+        startMs:
+          type: integer
+          minimum: 0
+          description: The start of the matching annotation, in milliseconds from the beginning of the media.
+          example: 83000
+        endMs:
+          type: integer
+          minimum: 0
+          description: The end of the matching annotation, in milliseconds from the beginning of the media.
+          example: 87500
+        highlight:
+          type: array
+          items:
+            type: string
+          description: Matched text fragments from this annotation, using the same marking convention as `searchExtra.highlight`.
     Entity:
       type: object
       description: |
@@ -1160,7 +1327,16 @@ components:
                 type: array
                 items:
                   type: string
-              description: Selected text snippets from fields matching the query, which can be displayed to users for context.
+              description: Selected text snippets from fields matching the query, which can be displayed to users for context. Matched terms are marked within each snippet; this specification is implementation-neutral about the specific mark tag (the examples use `<em>`).
+            segments:
+              type: array
+              items:
+                $ref: "#/components/schemas/Segment"
+              x-extension: segments
+              description: |
+                Part of the `segments` extension — see the [Extensions guide](https://language-research-technology.github.io/ro-crate-api/docs/getting-started/extensions). Only present when the implementation declares the `segments` extension in `/capabilities`.
+
+                Locations inside the file where the full-text match occurred, allowing clients to deep-link the user to the match (e.g. a PDF page or an ELAN annotation's time range). Segments are optional — absent or empty for hits without structured content. They are ranked by relevance and capped at an implementation-defined limit advertised as `maxSegments` in `/capabilities`.
     ValidationError:
       type: object
       required:
@@ -1402,6 +1578,18 @@ components:
               example: 550e8400-e29b-41d4-a716-446655440000
 
   examples:
+    CapabilitiesResponse:
+      summary: Example capabilities response
+      value:
+        apiVersion: "0.1.0"
+        extensions:
+          segments:
+            maxSegments: 5
+        facets:
+          inLanguage:
+            label: "Language"
+          mediaType: {}
+
     EntityResponse:
       summary: Example entity response
       value:
@@ -1540,6 +1728,37 @@ components:
                   - "Recordings of <em>West Alor</em> languages"
                 description:
                   - "featuring various West Alor languages, curated for <em>linguistic</em> research"
+          - id: "https://catalog.paradisec.org.au/repository/NT1/001/NT1-001-001A.pdf"
+            name: "NT1-001-001A.pdf"
+            description: "Field notes and transcription for the recording"
+            entityType: "http://schema.org/MediaObject"
+            memberOf:
+              id: "https://catalog.paradisec.org.au/repository/NT1/001"
+              name: "Recordings of West Alor languages"
+            rootCollection:
+              id: "https://catalog.paradisec.org.au/repository/NT1"
+              name: "South Efate (Vanuatu)"
+            metadataLicenseId: "https://catalog.paradisec.org.au/licenses/metadata"
+            contentLicenseId: "https://catalog.paradisec.org.au/licenses/content"
+            access:
+              metadata: true
+              content: true
+            searchExtra:
+              score: 0.87
+              highlight:
+                content:
+                  - "notes on <em>West Alor</em> vocabulary"
+              segments:
+                - type: "page"
+                  page: 3
+                  highlight:
+                    - "a wordlist of <em>West Alor</em> terms for kinship"
+                - type: "annotation"
+                  tier: "A_phrase-segnum-en"
+                  startMs: 83000
+                  endMs: 87500
+                  highlight:
+                    - "the speaker lists <em>West Alor</em> place names"
         facets:
           inLanguage:
             - name: "English"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -86,7 +86,7 @@ paths:
         ### Capabilities
         Declare what this implementation supports — the spec version it targets, the extensions it implements, and the search facets it provides. Every conformant implementation MUST provide this endpoint so that clients can feature-detect rather than relying on per-archive configuration or probing.
 
-        See the [Extensions guide](https://language-research-technology.github.io/ro-crate-api/docs/getting-started/extensions) for how extensions are registered and how clients should use this endpoint.
+        See the [Capabilities guide](https://language-research-technology.github.io/ro-crate-api/docs/getting-started/capabilities) for how clients should use this endpoint, and the [Extensions guide](https://language-research-technology.github.io/ro-crate-api/docs/getting-started/extensions) for how extensions are registered.
       operationId: getCapabilities
       responses:
         "200":

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -22,7 +22,7 @@ info:
 
     ## Extensions
 
-    The core specification can be extended through a curated registry of extensions defined in this document. Every extension has a stable identifier, a schema, and semantics. Implementations choose which extensions to implement and declare them through the `GET /capabilities` endpoint. Extension properties appear in core schemas as optional fields tagged with an `x-extension` annotation. See the [Extensions guide](https://language-research-technology.github.io/ro-crate-api/docs/getting-started/extensions) for the full extension model.
+    The core specification can be extended through a curated registry of extensions defined in this document. Every extension has a stable identifier, a schema, and semantics. Implementations choose which extensions to implement and declare them through the `GET /capabilities` endpoint. Extension properties appear in core schemas as optional fields tagged with an `x-extension` annotation. See the [Extensions guide](https://language-research-technology.github.io/ro-crate-api/docs/extensions) for the full extension model.
 
   contact:
     name: Issues
@@ -44,7 +44,7 @@ externalDocs:
   url: https://Language-Research-Technology.github.io/ro-crate-api
 tags:
   - name: capabilities
-    description: Endpoint for discovering what an implementation supports — the spec version it targets, the extensions it implements, and the search facets it provides.
+    description: Endpoint for discovering what an implementation supports — the spec version it targets, the extensions it implements, and the search filters and facets it provides.
     x-displayName: Capabilities
   - name: entities
     description: Endpoints related to the creation, retrieval, and management of RO-Crate entities.
@@ -84,9 +84,9 @@ paths:
       summary: Get implementation capabilities
       description: |
         ### Capabilities
-        Declare what this implementation supports — the spec version it targets, the extensions it implements, and the search facets it provides. Every conformant implementation MUST provide this endpoint so that clients can feature-detect rather than relying on per-archive configuration or probing.
+        Declare what this implementation supports — the spec version it targets, the extensions it implements, and the search filters and facets it provides. Every conformant implementation MUST provide this endpoint so that clients can feature-detect rather than relying on per-archive configuration or probing.
 
-        See the [Capabilities guide](https://language-research-technology.github.io/ro-crate-api/docs/getting-started/capabilities) for how clients should use this endpoint, and the [Extensions guide](https://language-research-technology.github.io/ro-crate-api/docs/getting-started/extensions) for how extensions are registered.
+        See the [Capabilities guide](https://language-research-technology.github.io/ro-crate-api/docs/getting-started/capabilities) for how clients should use this endpoint, and the [Extensions guide](https://language-research-technology.github.io/ro-crate-api/docs/extensions) for how extensions are registered.
       operationId: getCapabilities
       responses:
         "200":
@@ -405,15 +405,20 @@ paths:
                 filters:
                   type: object
                   description: |
-                    A set of key-value pairs representing additional filters. Keys can be metadata fields (like `inLanguage` or `mediaType`), with each value being an array of acceptable values.
+                    A set of key-value pairs representing additional filters. Keys MUST be filter fields the implementation declares in `/capabilities` under `search.filters`; a request using an undeclared key MUST be rejected with a 400 `ValidationError`.
+
+                    Each value is either an array of acceptable values (matched as exact terms, valid for any filter type) or a range object with inclusive `gte`/`lte` bounds (valid only for filters declared with type `date` or `number`). A range sent to a `string` or `boolean` filter MUST be rejected with a 400 `ValidationError`.
                   additionalProperties:
-                    type: array
-                    items:
-                      type: string
+                    oneOf:
+                      - type: array
+                        items:
+                          type: string
+                      - $ref: "#/components/schemas/FilterRange"
                   example:
                     {
                       "inLanguage": ["English", "Japanese"],
                       "mediaType": ["image/png"],
+                      "createdAt": { "gte": "2020-01-01", "lte": "2021-01-01" },
                     }
                 boundingBox:
                   type: object
@@ -1059,11 +1064,11 @@ components:
       description: Used to specify the order in sorting results.
     Capabilities:
       type: object
-      description: Declares what an implementation supports — the spec version it targets, the registered extensions it implements, and the search facets it provides.
+      description: Declares what an implementation supports — the spec version it targets, the registered extensions it implements, and the search filters and facets it provides.
       required:
         - apiVersion
         - extensions
-        - facets
+        - search
       properties:
         apiVersion:
           type: string
@@ -1072,7 +1077,7 @@ components:
         extensions:
           type: object
           description: |
-            The registered extensions this implementation provides, as a map of extension identifier to the extension's configuration object. Presence of a key means the extension is implemented; the value is an empty object when the extension has nothing to configure.
+            The registered extensions this implementation provides, as a map of extension identifier to a details object describing how the extension is provided. Presence of a key means the extension is implemented; the value is an empty object when the extension has no extra details to communicate.
 
             Unregistered experimental extensions use an `x-` prefixed identifier and are outside the scope of this specification.
           properties:
@@ -1082,11 +1087,36 @@ components:
           additionalProperties:
             type: object
           example:
-            segments:
-              maxSegments: 5
+            segments: {}
+        search:
+          $ref: "#/components/schemas/SearchCapability"
+    SearchCapability:
+      type: object
+      description: |
+        Declares what the implementation's search endpoint supports — the filters that may be used in search requests and the facets returned in search responses.
+
+        Every field declared in `facets` MUST also be declared in `filters`, so that clients can always turn a facet value the user clicks into a filter on the next request. Filter-only fields (for example date fields, which are filterable but not meaningful as facets) are permitted.
+      required:
+        - filters
+        - facets
+      properties:
+        filters:
+          type: object
+          description: The fields that may be used in the search request's `filters` object, as a map of field name to a declaration of the field's type and display label. Requests using a field not declared here MUST be rejected with a 400 `ValidationError`.
+          additionalProperties:
+            $ref: "#/components/schemas/FilterCapability"
+          example:
+            inLanguage:
+              type: string
+              label: Language
+            mediaType:
+              type: string
+            createdAt:
+              type: date
+              label: Date created
         facets:
           type: object
-          description: The facet fields the implementation supports in search responses, as a map of facet field name to configuration.
+          description: The facet fields the implementation supports in search responses, as a map of facet field name to its declaration. Every field listed here MUST also appear in `filters`.
           additionalProperties:
             $ref: "#/components/schemas/FacetCapability"
           example:
@@ -1095,24 +1125,56 @@ components:
             mediaType: {}
     SegmentsCapability:
       type: object
-      description: Configuration for the `segments` extension.
+      description: Details the implementation communicates about its `segments` support. The extension currently has no extra details to communicate; the value is an empty object.
       x-extension: segments
-      required:
-        - maxSegments
-      properties:
-        maxSegments:
-          type: integer
-          minimum: 1
-          description: The implementation-defined maximum number of segments returned per search hit.
-          example: 5
     FacetCapability:
       type: object
-      description: Configuration for a search facet field.
+      description: Describes a search facet field the implementation supports.
       properties:
         label:
           type: string
           description: An optional human-readable display label for the facet field.
           example: Language
+    FilterCapability:
+      type: object
+      description: |
+        Describes a search filter field the implementation supports. The `type` tells clients which UI element suits the field (e.g. a date picker for `date`, a toggle for `boolean`) and which request syntax the field accepts: `date` and `number` filters accept a range object as well as an array of values; `string` and `boolean` filters accept an array of values only.
+
+        New filter types are added by revision of this specification; clients MUST hide filters with a `type` value they do not recognise rather than fail.
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          enum:
+            - string
+            - date
+            - number
+            - boolean
+          description: The filter's value type. `date` values are ISO 8601 strings. `boolean` values are the strings `"true"` and `"false"`.
+          example: date
+        label:
+          type: string
+          description: An optional human-readable display label for the filter field.
+          example: Date created
+    FilterRange:
+      type: object
+      description: An inclusive range constraint for a search filter. Valid only for filters declared with type `date` or `number` in `/capabilities`. At least one bound is required; values are ISO 8601 strings for `date` filters and numbers for `number` filters.
+      minProperties: 1
+      additionalProperties: false
+      properties:
+        gte:
+          oneOf:
+            - type: string
+            - type: number
+          description: The inclusive lower bound.
+          example: "2020-01-01"
+        lte:
+          oneOf:
+            - type: string
+            - type: number
+          description: The inclusive upper bound.
+          example: "2021-01-01"
     Segment:
       description: |
         A location inside a file where a full-text search match occurred, allowing clients to deep-link the user to the match. Part of the `segments` extension.
@@ -1121,12 +1183,12 @@ components:
       x-extension: segments
       oneOf:
         - $ref: "#/components/schemas/PageSegment"
-        - $ref: "#/components/schemas/AnnotationSegment"
+        - $ref: "#/components/schemas/TimeAlignedAnnotationSegment"
       discriminator:
         propertyName: type
         mapping:
           page: "#/components/schemas/PageSegment"
-          annotation: "#/components/schemas/AnnotationSegment"
+          time-aligned-annotation: "#/components/schemas/TimeAlignedAnnotationSegment"
     PageSegment:
       type: object
       description: A search match located on a page of a paginated document, such as a PDF.
@@ -1151,7 +1213,7 @@ components:
           items:
             type: string
           description: Matched text fragments from this page, using the same marking convention as `searchExtra.highlight`.
-    AnnotationSegment:
+    TimeAlignedAnnotationSegment:
       type: object
       description: A search match located in a time-aligned annotation, such as an ELAN annotation tier.
       x-extension: segments
@@ -1165,7 +1227,7 @@ components:
         type:
           type: string
           enum:
-            - annotation
+            - time-aligned-annotation
           description: The segment type discriminator.
         tier:
           type: string
@@ -1334,9 +1396,9 @@ components:
                 $ref: "#/components/schemas/Segment"
               x-extension: segments
               description: |
-                Part of the `segments` extension — see the [Extensions guide](https://language-research-technology.github.io/ro-crate-api/docs/getting-started/extensions). Only present when the implementation declares the `segments` extension in `/capabilities`.
+                Part of the `segments` extension — see the [Extensions guide](https://language-research-technology.github.io/ro-crate-api/docs/extensions). Only present when the implementation declares the `segments` extension in `/capabilities`.
 
-                Locations inside the file where the full-text match occurred, allowing clients to deep-link the user to the match (e.g. a PDF page or an ELAN annotation's time range). Segments are optional — absent or empty for hits without structured content. They are ranked by relevance and capped at an implementation-defined limit advertised as `maxSegments` in `/capabilities`.
+                Locations inside the file where the full-text match occurred, allowing clients to deep-link the user to the match (e.g. a PDF page or an ELAN annotation's time range). Segments are optional — absent or empty for hits without structured content. They are ranked by relevance and capped at an implementation-defined limit.
     ValidationError:
       type: object
       required:
@@ -1583,12 +1645,21 @@ components:
       value:
         apiVersion: "0.1.0"
         extensions:
-          segments:
-            maxSegments: 5
-        facets:
-          inLanguage:
-            label: "Language"
-          mediaType: {}
+          segments: {}
+        search:
+          filters:
+            inLanguage:
+              type: "string"
+              label: "Language"
+            mediaType:
+              type: "string"
+            createdAt:
+              type: "date"
+              label: "Date created"
+          facets:
+            inLanguage:
+              label: "Language"
+            mediaType: {}
 
     EntityResponse:
       summary: Example entity response
@@ -1689,6 +1760,9 @@ components:
             - "English"
           mediaType:
             - "audio/mpeg"
+          createdAt:
+            gte: "2020-01-01"
+            lte: "2021-01-01"
         boundingBox:
           topRight:
             lat: -33.7
@@ -1753,7 +1827,7 @@ components:
                   page: 3
                   highlight:
                     - "a wordlist of <em>West Alor</em> terms for kinship"
-                - type: "annotation"
+                - type: "time-aligned-annotation"
                   tier: "A_phrase-segnum-en"
                   startMs: 83000
                   endMs: 87500

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -33,6 +33,15 @@ const sidebars: SidebarsConfig = {
     },
     {
       type: 'category',
+      label: 'Extensions',
+      link: {
+        type: 'doc',
+        id: 'extensions/index',
+      },
+      items: ['extensions/segments', 'extensions/legacy'],
+    },
+    {
+      type: 'category',
       label: 'API',
       link: {
         type: 'generated-index',


### PR DESCRIPTION
Implements #17.

## What this does

Makes extensions first-class citizens of the specification:

- **Extension registry**: extensions are defined in the OpenAPI document with stable identifiers, schemas, and semantics. Extension properties appear inline in core schemas as optional fields tagged `x-extension: <id>`. Unregistered private experiments use an `x-` prefixed identifier.
- **`GET /capabilities`** (new required endpoint): every conformant implementation declares the spec version it targets (`apiVersion`), its implemented extensions (`extensions` — a map of extension id to configuration object), and its supported search facets (`facets` — a map of field name to configuration with an optional display `label`).
- **`segments` — the first registered extension**: an optional `searchExtra.segments` array on search hits carrying structured drill-down locations for full-text matches inside files, as a discriminated union on `type`:
  - `PageSegment`: 1-based `page` number plus highlight fragments (PDF matches)
  - `AnnotationSegment`: `tier` (ELAN TIER_ID), `startMs`/`endMs` plus highlight fragments (transcription matches)

  Segments are optional, ranked by relevance, capped at an implementation-defined limit advertised as `maxSegments` in `/capabilities`; clients MUST skip segments with unrecognised `type` values.
- **Versioning**: spec bumped 0.0.1 → 0.1.0 (a required endpoint is conformance-affecting), `CHANGELOG.md` started, and a blog post announces the framework.
- **Docs**: the Extensions guide is rewritten around the extension model, the curated registry, feature detection, and client rules; the legacy Oni-UI properties remain documented under "Legacy Extensions (Pending Registration)" — registering them is tracked in #18.

## Verification

- `pnpm lint` (tsc, biome, redocly) passes with no rule suppressions — the Redocly lint validates the new examples against their schemas, including the spec's first `discriminator`.
- `pnpm build` succeeds; the discriminator renders correctly on the generated Segment schema page, and the search response example shows both segment variants.

## Cross-repo consequences

Making `/capabilities` required creates a build obligation for both implementations: nabu should advertise `segments` (cap of 5) plus its facets, and arocapi needs the endpoint even without segments. The sibling PRDs in those repositories should be updated accordingly (upstream design source: paradisec-archive/nabu#1155).